### PR TITLE
Add support for generating Mermaid diagrams from Layup models

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ graph LR
       github_buf_organization_url[httpd://github.com/bufbuild]
     end
 
-    github_my_account-->|owner|this_repository
+    github_my_account-->|owner|github_this_repository
   end
 
   subgraph go
@@ -443,8 +443,8 @@ graph LR
       go_runtime_url[https://golang.org/pkg/runtime]
     end
 
-    go_owner-->|stewardship|language
-    go_language-->|implementation|runtime
+    go_owner-->|stewardship|go_language
+    go_language-->|implementation|go_runtime
   end
 
   subgraph buf
@@ -466,7 +466,7 @@ graph LR
     subgraph layup_cli
     end
 
-    layup_hcl-->|conversion|schema
+    layup_hcl-->|conversion|layup_schema
     layup_schema-->|schmea_source_code_genration|buf_cli
     layup_schema-->|schema_source_code|github_this_repository
     layup_cli-->|uses|go_runtime

--- a/README.md
+++ b/README.md
@@ -414,61 +414,63 @@ layer "layup" {
 
 ```mermaid
 graph LR
-    subgraph github
-        subgraph my_account
-            my_account_url[httpd://github.com/picatz]
-        end
-        subgraph this_repository
-            this_repository_url[httpd://github.com/picatz/layup]
-        end
-        subgraph buf_organization
-            buf_organization_url[httpd://github.com/bufbuild]
-        end
-
-        my_account-->|owner|this_repository 
+  subgraph github
+    subgraph github_my_account
+      github_my_account_url[httpd://github.com/picatz]
     end
 
-    subgraph go
-        subgraph owner
-            owner_url[https://google.com]
-        end
-
-        subgraph language
-            language_url[https://golang.org]
-        end
-
-        subgraph runtime
-            runtime_url[https://golang.org/pkg/runtime]
-        end
-
-        owner-->|stewardship|language
-        language-->|implementation|runtime
+    subgraph github_this_repository
+      github_this_repository_url[httpd://github.com/picatz/layup]
     end
 
-    subgraph buf
-        subgraph buf_cli
-            cli_url[https://buf.build/docs/installation]
-        end
-
-        buf_cli-->|maintenance|buf_organization
-        buf_cli-->|uses|runtime
+    subgraph github_buf_organization
+      github_buf_organization_url[httpd://github.com/bufbuild]
     end
 
-    subgraph layup
-        subgraph schema
-        end
+    github_my_account-->|owner|this_repository
+  end
 
-        subgraph hcl
-        end
-
-        subgraph cli
-        end
-
-        hcl -->|conversion|schema
-        schema -->|schmea_source_code_genration|buf_cli
-        schema -->|schema_source_code|this_repository
-        cli-->|uses|runtime
+  subgraph go
+    subgraph go_owner
+      go_owner_url[https://google.com]
     end
+
+    subgraph go_language
+      go_language_url[https://golang.org]
+    end
+
+    subgraph go_runtime
+      go_runtime_url[https://golang.org/pkg/runtime]
+    end
+
+    go_owner-->|stewardship|language
+    go_language-->|implementation|runtime
+  end
+
+  subgraph buf
+    subgraph buf_cli
+      buf_cli_url[https://buf.build/docs/installation]
+    end
+
+    buf_cli-->|maintenance|github_buf_organization
+    buf_cli-->|uses|go_runtime
+  end
+
+  subgraph layup
+    subgraph layup_schema
+    end
+
+    subgraph layup_hcl
+    end
+
+    subgraph layup_cli
+    end
+
+    layup_hcl-->|conversion|schema
+    layup_schema-->|schmea_source_code_genration|buf_cli
+    layup_schema-->|schema_source_code|github_this_repository
+    layup_cli-->|uses|go_runtime
+  end
 ```
 
 <!-- Links -->

--- a/pkg/layup/v1/layup_mermaid.go
+++ b/pkg/layup/v1/layup_mermaid.go
@@ -59,6 +59,8 @@ func WriteMermiad(w io.Writer, m *Model) error {
 
 				// Replace the "/nodes/" with _ to match the node ID.
 				linkToID = strings.Replace(linkToID, "/nodes/", "_", 1)
+			} else {
+				linkToID = layer.Id + "_" + link.To
 			}
 
 			bw.WriteString("\t\t" + layer.Id + "_" + link.From + "-->" + "|" + link.Id + "|" + linkToID + "\n")

--- a/pkg/layup/v1/layup_mermaid.go
+++ b/pkg/layup/v1/layup_mermaid.go
@@ -1,0 +1,71 @@
+package layupv1
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+// WriteMermiad writes a Mermaid graph to the given writer using the
+// given Layup model's data.
+func WriteMermiad(w io.Writer, m *Model) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	defer tw.Flush()
+
+	bw := bufio.NewWriter(tw)
+	defer bw.Flush()
+
+	bw.WriteString("graph LR\n")
+
+	for _, layer := range m.Layers {
+		bw.WriteString("\tsubgraph " + layer.Id + "\n")
+
+		for _, n := range layer.Nodes {
+			bw.WriteString("\t\tsubgraph " + layer.Id + "_" + n.Id + "\n")
+			for k, v := range n.Attributes {
+				var attrStr string
+
+				switch v.GetKind().(type) {
+				case *structpb.Value_NumberValue:
+					attrStr = fmt.Sprintf("%s_%s_%s[%f]", layer.Id, n.Id, k, v.GetNumberValue())
+				case *structpb.Value_StringValue:
+					attrStr = fmt.Sprintf("%s_%s_%s[%s]", layer.Id, n.Id, k, v.GetStringValue())
+				case *structpb.Value_BoolValue:
+					attrStr = fmt.Sprintf("%s_%s_%s[%t]", layer.Id, n.Id, k, v.GetBoolValue())
+				}
+
+				bw.WriteString("\t\t\t" + attrStr + "\n")
+			}
+			bw.WriteString("\t\tend\n\n")
+		}
+
+		for _, link := range layer.Links {
+			linkToID := link.To
+
+			// If the link has an ID, use that as the label, otherwise
+			// if it's using a URI, we need to clean it up a bit to match
+			// mermiad's syntax. We control the ID of each node in the subgraph,
+			// so this is fairly safe.
+			if strings.Contains(linkToID, "://") {
+				linkToID = strings.TrimPrefix(linkToID, m.GetUri())
+
+				// The link is likely to be a URI to a different layer, so we need
+				// to remove the layer name from the URI.
+				linkToID = strings.TrimPrefix(linkToID, "/layers/")
+
+				// Replace the "/nodes/" with _ to match the node ID.
+				linkToID = strings.Replace(linkToID, "/nodes/", "_", 1)
+			}
+
+			bw.WriteString("\t\t" + layer.Id + "_" + link.From + "-->" + "|" + link.Id + "|" + linkToID + "\n")
+		}
+
+		bw.WriteString("\tend\n\n")
+	}
+
+	return nil
+}

--- a/pkg/layup/v1/layup_mermaid_test.go
+++ b/pkg/layup/v1/layup_mermaid_test.go
@@ -1,0 +1,24 @@
+package layupv1_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	layupv1 "github.com/picatz/layup/pkg/layup/v1"
+)
+
+func TestWriteMermaid(t *testing.T) {
+	model, err := layupv1.ParseHCL(strings.NewReader(thisProject))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mermaidBuffer := strings.Builder{}
+
+	if err := layupv1.WriteMermiad(&mermaidBuffer, model); err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Println(mermaidBuffer.String())
+}


### PR DESCRIPTION
This PR aims to add support for generating Mermaid (graph) diagrams from Layup models. This does _not_ allow for Mermaid to Layup Models. But, it allows for visualization for model contents that is easily renderable on GitHub. I've updated the `README.md` file in this repository to use the automatically generated diagram.

```hcl
uri = "layup://example"

layer "github" {
    node "my_account" {
        url = "httpd://github.com/picatz"
    }

    node "this_repository" {
        url = "httpd://github.com/picatz/layup"
    }

    node "buf_organization" {
        url = "httpd://github.com/bufbuild"
    }

    link "owner" {
        from = "my_account"
        to = "this_repository"
    }
}

layer "go" {
    node "owner" {
        url = "https://google.com"
    }

    node "language" {
        url = "https://golang.org"
    }

    node "runtime" {
        url = "https://golang.org/pkg/runtime"
    }

    link "stewardship" {
        from = "owner"
        to = "language"
    }

    link "implementation" {
        from = "language"
        to = "runtime"
    }
}

layer "buf" {
    node "cli" {
        url = "https://buf.build/docs/installation"
    }

    link "maintenance" {
        from = "cli"
        to = layer.github.node.buf_organization
    }

    link "uses" {
        from = "cli"
        to = layer.go.node.runtime
    }
}

layer "layup" {
    node "schema" {}

    node "hcl" {}

    node "cli" {}

    link "conversion" {
        from = "hcl"
        to = "schema"
    }

    link "schmea_source_code_genration" {
        from = "schema"
        to = layer.buf.node.cli
    }

    link "schema_source_code" {
        from = "schema"
        to = layer.github.node.this_repository
    }

    link "uses" {
        from = "cli"
        to = layer.go.node.runtime
    }
}
```

```mermaid
graph LR
  subgraph github
    subgraph github_my_account
      github_my_account_url[httpd://github.com/picatz]
    end

    subgraph github_this_repository
      github_this_repository_url[httpd://github.com/picatz/layup]
    end

    subgraph github_buf_organization
      github_buf_organization_url[httpd://github.com/bufbuild]
    end

    github_my_account-->|owner|github_this_repository
  end

  subgraph go
    subgraph go_owner
      go_owner_url[https://google.com]
    end

    subgraph go_language
      go_language_url[https://golang.org]
    end

    subgraph go_runtime
      go_runtime_url[https://golang.org/pkg/runtime]
    end

    go_owner-->|stewardship|go_language
    go_language-->|implementation|go_runtime
  end

  subgraph buf
    subgraph buf_cli
      buf_cli_url[https://buf.build/docs/installation]
    end

    buf_cli-->|maintenance|github_buf_organization
    buf_cli-->|uses|go_runtime
  end

  subgraph layup
    subgraph layup_schema
    end

    subgraph layup_hcl
    end

    subgraph layup_cli
    end

    layup_hcl-->|conversion|layup_schema
    layup_schema-->|schmea_source_code_genration|buf_cli
    layup_schema-->|schema_source_code|github_this_repository
    layup_cli-->|uses|go_runtime
  end
```