### PR TITLE
Add support for DOT encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,15 +186,15 @@ uri = "layup://example"
 
 layer "github" {
     node "my_account" {
-        url = "httpd://github.com/picatz"
+        url = "https://github.com/picatz"
     }
 
     node "this_repository" {
-        url = "httpd://github.com/picatz/layup"
+        url = "https://github.com/picatz/layup"
     }
 
     node "buf_organization" {
-        url = "httpd://github.com/bufbuild"
+        url = "https://github.com/bufbuild"
     }
 
     link "owner" {
@@ -288,19 +288,19 @@ layer "layup" {
         {
           "id": "my_account",
           "attributes": {
-            "url": "httpd://github.com/picatz"
+            "url": "https://github.com/picatz"
           }
         },
         {
           "id": "this_repository",
           "attributes": {
-            "url": "httpd://github.com/picatz/layup"
+            "url": "https://github.com/picatz/layup"
           }
         },
         {
           "id": "buf_organization",
           "attributes": {
-            "url": "httpd://github.com/bufbuild"
+            "url": "https://github.com/bufbuild"
           }
         }
       ],
@@ -416,15 +416,15 @@ layer "layup" {
 graph LR
   subgraph github
     subgraph github_my_account
-      github_my_account_url[httpd://github.com/picatz]
+      github_my_account_url[https://github.com/picatz]
     end
 
     subgraph github_this_repository
-      github_this_repository_url[httpd://github.com/picatz/layup]
+      github_this_repository_url[https://github.com/picatz/layup]
     end
 
     subgraph github_buf_organization
-      github_buf_organization_url[httpd://github.com/bufbuild]
+      github_buf_organization_url[https://github.com/bufbuild]
     end
 
     github_my_account-->|owner|github_this_repository

--- a/pkg/layup/v1/layup_dot.go
+++ b/pkg/layup/v1/layup_dot.go
@@ -19,13 +19,18 @@ func WriteDOT(w io.Writer, m *Model) error {
 	bw := bufio.NewWriter(tw)
 	defer bw.Flush()
 
-	bw.WriteString("digraph G {\n")
+	bw.WriteString(fmt.Sprintf("digraph %q {\n", m.GetUri()))
+	bw.WriteString(fmt.Sprintf("\tlabel=%q\n", m.GetUri()))
+	bw.WriteString("\tcompound=true\n")
+	bw.WriteString("\tnode [shape=box]\n")
 
 	for _, layer := range m.Layers {
 		bw.WriteString("\tsubgraph cluster_" + layer.Id + " {\n")
+		bw.WriteString(fmt.Sprintf("\t\tlabel=%q\n", layer.Id))
 
 		for _, n := range layer.Nodes {
 			bw.WriteString("\t\t" + layer.Id + "_" + n.Id + " [\n")
+			bw.WriteString("\t\t\tlabel=" + fmt.Sprintf("%q", n.Id) + "\n")
 			for k, v := range n.Attributes {
 				var attrStr string
 

--- a/pkg/layup/v1/layup_dot.go
+++ b/pkg/layup/v1/layup_dot.go
@@ -1,0 +1,75 @@
+package layupv1
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	structpb "google.golang.org/protobuf/types/known/structpb"
+)
+
+// WriteDOT writes a DOT graph to the given writer using the
+// given Layup model's data.
+func WriteDOT(w io.Writer, m *Model) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	defer tw.Flush()
+
+	bw := bufio.NewWriter(tw)
+	defer bw.Flush()
+
+	bw.WriteString("digraph G {\n")
+
+	for _, layer := range m.Layers {
+		bw.WriteString("\tsubgraph cluster_" + layer.Id + " {\n")
+
+		for _, n := range layer.Nodes {
+			bw.WriteString("\t\t" + layer.Id + "_" + n.Id + " [\n")
+			for k, v := range n.Attributes {
+				var attrStr string
+
+				switch v.GetKind().(type) {
+				case *structpb.Value_NumberValue:
+					attrStr = fmt.Sprintf("%s=%f", k, v.GetNumberValue())
+				case *structpb.Value_StringValue:
+					attrStr = fmt.Sprintf("%s=%q", k, v.GetStringValue())
+				case *structpb.Value_BoolValue:
+					attrStr = fmt.Sprintf("%s=%t", k, v.GetBoolValue())
+				}
+
+				bw.WriteString("\t\t\t" + attrStr + "\n")
+			}
+			bw.WriteString("\t\t]\n\n")
+		}
+
+		for _, link := range layer.Links {
+			linkToID := link.To
+
+			// If the link has an ID, use that as the label, otherwise
+			// if it's using a URI, we need to clean it up a bit to match
+			// mermiad's syntax. We control the ID of each node in the subgraph,
+			// so this is fairly safe.
+			if strings.Contains(linkToID, "://") {
+				linkToID = strings.TrimPrefix(linkToID, m.GetUri())
+
+				// The link is likely to be a URI to a different layer, so we need
+				// to remove the layer name from the URI.
+				linkToID = strings.TrimPrefix(linkToID, "/layers/")
+
+				// Replace the "/nodes/" with _ to match the node ID.
+				linkToID = strings.Replace(linkToID, "/nodes/", "_", 1)
+			} else {
+				linkToID = fmt.Sprintf("%s_%s", layer.Id, link.To)
+			}
+
+			bw.WriteString("\t\t" + fmt.Sprintf("%s_%s -> %s [label=\"%s\"]", layer.Id, link.From, linkToID, link.Id) + "\n")
+		}
+
+		bw.WriteString("\t}\n")
+	}
+
+	bw.WriteString("}\n")
+
+	return nil
+}

--- a/pkg/layup/v1/layup_dot_test.go
+++ b/pkg/layup/v1/layup_dot_test.go
@@ -1,0 +1,25 @@
+package layupv1_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	layupv1 "github.com/picatz/layup/pkg/layup/v1"
+)
+
+func TestWriteDOT(t *testing.T) {
+	model, err := layupv1.ParseHCL(strings.NewReader(thisProject))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dotBuffer := strings.Builder{}
+
+	err = layupv1.WriteDOT(&dotBuffer, model)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Println(dotBuffer.String())
+}

--- a/pkg/layup/v1/layup_hcl_test.go
+++ b/pkg/layup/v1/layup_hcl_test.go
@@ -13,15 +13,15 @@ var thisProject = `uri = "layup://example"
 
 layer "github" {
     node "my_account" {
-        url = "httpd://github.com/picatz"
+        url = "https://github.com/picatz"
     }
 
     node "this_repository" {
-        url = "httpd://github.com/picatz/layup"
+        url = "https://github.com/picatz/layup"
     }
 
     node "buf_organization" {
-        url = "httpd://github.com/bufbuild"
+        url = "https://github.com/bufbuild"
     }
 
     link "owner" {


### PR DESCRIPTION
This PR adds the `layupv1.WriteDOT` function which can be used to encode a given model to [DOT](https://en.wikipedia.org/wiki/DOT_(graph_description_language)) format.

## HCL

```hcl
uri = "layup://example"

layer "github" {
    node "my_account" {
        url = "https://github.com/picatz"
    }

    node "this_repository" {
        url = "https://github.com/picatz/layup"
    }

    node "buf_organization" {
        url = "https://github.com/bufbuild"
    }

    link "owner" {
        from = "my_account"
        to = "this_repository"
    }
}

layer "go" {
    node "owner" {
        url = "https://google.com"
    }

    node "language" {
        url = "https://golang.org"
    }

    node "runtime" {
        url = "https://golang.org/pkg/runtime"
    }

    link "stewardship" {
        from = "owner"
        to = "language"
    }

    link "implementation" {
        from = "language"
        to = "runtime"
    }
}

layer "buf" {
    node "cli" {
        url = "https://buf.build/docs/installation"
    }

    link "maintenance" {
        from = "cli"
        to = layer.github.node.buf_organization
    }

    link "uses" {
        from = "cli"
        to = layer.go.node.runtime
    }
}

layer "layup" {
    node "schema" {}

    node "hcl" {}

    node "cli" {}

    link "conversion" {
        from = "hcl"
        to = "schema"
    }

    link "schmea_source_code_genration" {
        from = "schema"
        to = layer.buf.node.cli
    }

    link "schema_source_code" {
        from = "schema"
        to = layer.github.node.this_repository
    }

    link "uses" {
        from = "cli"
        to = layer.go.node.runtime
    }
}
```

## DOT

```dot
digraph "layup://example" {
  label="layup://example"
  compound=true
  node [shape=box]
  focus=true

  subgraph cluster_github {
    label="github"
    github_my_account [
      label="my_account"
      url="https://github.com/picatz"
    ]

    github_this_repository [
      label="this_repository"
      url="https://github.com/picatz/layup"
    ]

    github_buf_organization [
      label="buf_organization"
      url="https://github.com/bufbuild"
    ]

    github_my_account -> github_this_repository [label="owner"]
  }
  subgraph cluster_go {
    label="go"
    go_owner [
      label="owner"
      url="https://google.com"
    ]

    go_language [
      label="language"
      url="https://golang.org"
    ]

    go_runtime [
      label="runtime"
      url="https://golang.org/pkg/runtime"
    ]

    go_owner -> go_language [label="stewardship"]
    go_language -> go_runtime [label="implementation"]
  }
  subgraph cluster_buf {
    label="buf"
    buf_cli [
      label="cli"
      url="https://buf.build/docs/installation"
    ]

    buf_cli -> github_buf_organization [label="maintenance"]
    buf_cli -> go_runtime [label="uses"]
  }
  subgraph cluster_layup {
    label="layup"
    layup_schema [
      label="schema"
    ]

    layup_hcl [
      label="hcl"
    ]

    layup_cli [
      label="cli"
    ]

    layup_hcl -> layup_schema [label="conversion"]
    layup_schema -> buf_cli [label="schmea_source_code_genration"]
    layup_schema -> github_this_repository [label="schema_source_code"]
    layup_cli -> go_runtime [label="uses"]
  }
}
```

## Graphviz

![graphviz](https://github.com/picatz/layup/assets/14850816/a7d0327a-bdf4-43c1-9068-fb41d3fdf7a1)


