### PR TITLE
Add support for D2 encoding

### DIFF
--- a/pkg/layup/v1/layup_d2.go
+++ b/pkg/layup/v1/layup_d2.go
@@ -1,0 +1,75 @@
+package layupv1
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+	"text/tabwriter"
+
+	structpb "google.golang.org/protobuf/types/known/structpb"
+)
+
+// WriteD2 writes a D2 (Terrastruct) graph to the given writer using the
+// given Layup model's data.
+func WriteD2(w io.Writer, m *Model) error {
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	defer tw.Flush()
+
+	bw := bufio.NewWriter(tw)
+	defer bw.Flush()
+
+	for _, layer := range m.Layers {
+		bw.WriteString(layer.Id + ": {\n")
+
+		for _, n := range layer.Nodes {
+			bw.WriteString("\t" + n.Id + ": {\n")
+			for k, v := range n.Attributes {
+				var attrStr string
+
+				switch v.GetKind().(type) {
+				case *structpb.Value_NumberValue:
+					attrStr = fmt.Sprintf("%s = %f", k, v.GetNumberValue())
+				case *structpb.Value_StringValue:
+					attrStr = fmt.Sprintf("%s = %q", k, v.GetStringValue())
+				case *structpb.Value_BoolValue:
+					attrStr = fmt.Sprintf("%s = %t", k, v.GetBoolValue())
+				}
+
+				bw.WriteString("\t\t" + attrStr + "\n")
+			}
+			bw.WriteString("\t}\n\n")
+		}
+
+		bw.WriteString("}\n\n")
+	}
+
+	for _, layer := range m.Layers {
+		for _, link := range layer.Links {
+			linkToID := link.To
+
+			// If the link has an ID, use that as the label, otherwise
+			// if it's using a URI, we need to clean it up a bit to match
+			// mermiad's syntax. We control the ID of each node in the subgraph,
+			// so this is fairly safe.
+			if strings.Contains(linkToID, "://") {
+				linkToID = strings.TrimPrefix(linkToID, m.GetUri())
+
+				// The link is likely to be a URI to a different layer, so we need
+				// to remove the layer name from the URI.
+				linkToID = strings.TrimPrefix(linkToID, "/layers/")
+
+				// Replace the "/nodes/" with _ to match the node ID.
+				linkToID = strings.Replace(linkToID, "/nodes/", ".", 1)
+			} else {
+				linkToID = fmt.Sprintf("%s.%s", layer.Id, link.To)
+			}
+
+			linkFromID := fmt.Sprintf("%s.%s", layer.Id, link.From)
+
+			bw.WriteString("" + fmt.Sprintf("%s -> %s: %q", linkFromID, linkToID, link.Id) + "\n")
+		}
+	}
+
+	return nil
+}

--- a/pkg/layup/v1/layup_d2.go
+++ b/pkg/layup/v1/layup_d2.go
@@ -50,7 +50,7 @@ func WriteD2(w io.Writer, m *Model) error {
 
 			// If the link has an ID, use that as the label, otherwise
 			// if it's using a URI, we need to clean it up a bit to match
-			// mermiad's syntax. We control the ID of each node in the subgraph,
+			// D2's syntax. We control the ID of each node in the subgraph,
 			// so this is fairly safe.
 			if strings.Contains(linkToID, "://") {
 				linkToID = strings.TrimPrefix(linkToID, m.GetUri())

--- a/pkg/layup/v1/layup_d2_test.go
+++ b/pkg/layup/v1/layup_d2_test.go
@@ -1,0 +1,25 @@
+package layupv1_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	layupv1 "github.com/picatz/layup/pkg/layup/v1"
+)
+
+func TestWriteD2(t *testing.T) {
+	model, err := layupv1.ParseHCL(strings.NewReader(thisProject))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	d2Buffer := strings.Builder{}
+
+	err = layupv1.WriteD2(&d2Buffer, model)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fmt.Println(d2Buffer.String())
+}

--- a/pkg/layup/v1/layup_dot.go
+++ b/pkg/layup/v1/layup_dot.go
@@ -68,7 +68,7 @@ func WriteDOT(w io.Writer, m *Model) error {
 				linkToID = fmt.Sprintf("%s_%s", layer.Id, link.To)
 			}
 
-			bw.WriteString("\t\t" + fmt.Sprintf("%s_%s -> %s [label=\"%s\"]", layer.Id, link.From, linkToID, link.Id) + "\n")
+			bw.WriteString("\t\t" + fmt.Sprintf("%s_%s -> %s [label=%q]", layer.Id, link.From, linkToID, link.Id) + "\n")
 		}
 
 		bw.WriteString("\t}\n")

--- a/pkg/layup/v1/layup_dot.go
+++ b/pkg/layup/v1/layup_dot.go
@@ -53,7 +53,7 @@ func WriteDOT(w io.Writer, m *Model) error {
 
 			// If the link has an ID, use that as the label, otherwise
 			// if it's using a URI, we need to clean it up a bit to match
-			// mermiad's syntax. We control the ID of each node in the subgraph,
+			// DOT's syntax. We control the ID of each node in the subgraph,
 			// so this is fairly safe.
 			if strings.Contains(linkToID, "://") {
 				linkToID = strings.TrimPrefix(linkToID, m.GetUri())


### PR DESCRIPTION
This PR adds the `layupv1.WriteD2` function which can be used to encode a given model to [D2](https://d2lang.com/) format.

## HCL

```hcl
uri = "layup://example"

layer "github" {
    node "my_account" {
        url = "https://github.com/picatz"
    }

    node "this_repository" {
        url = "https://github.com/picatz/layup"
    }

    node "buf_organization" {
        url = "https://github.com/bufbuild"
    }

    link "owner" {
        from = "my_account"
        to = "this_repository"
    }
}

layer "go" {
    node "owner" {
        url = "https://google.com"
    }

    node "language" {
        url = "https://golang.org"
    }

    node "runtime" {
        url = "https://golang.org/pkg/runtime"
    }

    link "stewardship" {
        from = "owner"
        to = "language"
    }

    link "implementation" {
        from = "language"
        to = "runtime"
    }
}

layer "buf" {
    node "cli" {
        url = "https://buf.build/docs/installation"
    }

    link "maintenance" {
        from = "cli"
        to = layer.github.node.buf_organization
    }

    link "uses" {
        from = "cli"
        to = layer.go.node.runtime
    }
}

layer "layup" {
    node "schema" {}

    node "hcl" {}

    node "cli" {}

    link "conversion" {
        from = "hcl"
        to = "schema"
    }

    link "schmea_source_code_genration" {
        from = "schema"
        to = layer.buf.node.cli
    }

    link "schema_source_code" {
        from = "schema"
        to = layer.github.node.this_repository
    }

    link "uses" {
        from = "cli"
        to = layer.go.node.runtime
    }
}
```

## D2

```d2
github: {
  my_account: {
    url = "https://github.com/picatz"
  }

  this_repository: {
    url = "https://github.com/picatz/layup"
  }

  buf_organization: {
    url = "https://github.com/bufbuild"
  }

}

go: {
  owner: {
    url = "https://google.com"
  }

  language: {
    url = "https://golang.org"
  }

  runtime: {
    url = "https://golang.org/pkg/runtime"
  }

}

buf: {
  cli: {
    url = "https://buf.build/docs/installation"
  }

}

layup: {
  schema: {
  }

  hcl: {
  }

  cli: {
  }

}

github.my_account -> github.this_repository: "owner"
go.owner -> go.language: "stewardship"
go.language -> go.runtime: "implementation"
buf.cli -> github.buf_organization: "maintenance"
buf.cli -> go.runtime: "uses"
layup.hcl -> layup.schema: "conversion"
layup.schema -> buf.cli: "schmea_source_code_genration"
layup.schema -> github.this_repository: "schema_source_code"
layup.cli -> go.runtime: "uses"
```

## Dagre

![Dagre](https://github.com/picatz/layup/assets/14850816/e70e81cf-5e64-486f-9843-8ba6e4fc71f9)
